### PR TITLE
`FairBidSDK` version 3.25.0 + `MintegralAdsSDK` version 7.1.1.0

### DIFF
--- a/Fyber FairBid/AdsScreenViewController.swift
+++ b/Fyber FairBid/AdsScreenViewController.swift
@@ -11,10 +11,16 @@ class AdsScreenViewController: UIViewController {
 
     var adType: AdType!
 
-    private let interstitialPlacementID = "197405"
-    private let rewardedPlacementID = "197406"
-    private let bannerPlacementID = "197407"
-
+    private let interstitialPlacementID = "208904" //(Mintegral: 161687)
+    private let rewardedPlacementID = "208905" //(Mintegral: 161745)
+    private let bannerPlacementID = "545668" //(Mintegral: 1724179)
+    
+    /*
+    private let secondInterstitialPlacementID = "208906" //(Mintegral: 161689)
+    private let secondRewardedPlacementID = "208907" //(Mintegral: 161747)
+    private let secondBannerPlacementID = "551489" //(Mintegral: 1733319)
+    */
+    
     let formatter = DateFormatter()
 
     private var banner: FYBBannerAdView?

--- a/Fyber FairBid/AppDelegate.swift
+++ b/Fyber FairBid/AppDelegate.swift
@@ -17,7 +17,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         options.autoRequestingEnabled = false
         options.logLevel = .verbose
 
-        FairBid.start(withAppId: "109613", options: options)
+        FairBid.start(withAppId: "111691", options: options)
 
         return true
     }

--- a/Podfile
+++ b/Podfile
@@ -3,5 +3,12 @@ source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '10.0'
 
 target 'Fyber FairBid' do
-  pod 'FairBidSDK', '3.28.0'
+  pod 'FairBidSDK', '3.25.0'
+
+  pod 'MintegralAdSDK', '7.1.1.0'
+  pod 'MintegralAdSDK/RewardVideoAd', '7.1.1.0'
+  pod 'MintegralAdSDK/BidRewardVideoAd', '7.1.1.0'
+  pod 'MintegralAdSDK/InterstitialVideoAd', '7.1.1.0'
+  pod 'MintegralAdSDK/BidInterstitialVideoAd', '7.1.1.0'
+
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,58 @@
 PODS:
-  - FairBidSDK (3.28.0)
+  - FairBidSDK (3.25.0)
+  - MintegralAdSDK (7.1.1.0):
+    - MintegralAdSDK/BannerAd (= 7.1.1.0)
+    - MintegralAdSDK/BidBannerAd (= 7.1.1.0)
+    - MintegralAdSDK/BidInterstitialVideoAd (= 7.1.1.0)
+    - MintegralAdSDK/BidNativeAd (= 7.1.1.0)
+    - MintegralAdSDK/BidNewInterstitialAd (= 7.1.1.0)
+    - MintegralAdSDK/BidRewardVideoAd (= 7.1.1.0)
+    - MintegralAdSDK/InterstitialVideoAd (= 7.1.1.0)
+    - MintegralAdSDK/NativeAd (= 7.1.1.0)
+    - MintegralAdSDK/NewInterstitialAd (= 7.1.1.0)
+    - MintegralAdSDK/RewardVideoAd (= 7.1.1.0)
+  - MintegralAdSDK/BannerAd (7.1.1.0):
+    - MintegralAdSDK/NativeAd
+  - MintegralAdSDK/BidBannerAd (7.1.1.0):
+    - MintegralAdSDK/BannerAd
+    - MintegralAdSDK/BidNativeAd
+  - MintegralAdSDK/BidInterstitialVideoAd (7.1.1.0):
+    - MintegralAdSDK/BidNativeAd
+    - MintegralAdSDK/InterstitialVideoAd
+  - MintegralAdSDK/BidNativeAd (7.1.1.0):
+    - MintegralAdSDK/NativeAd
+  - MintegralAdSDK/BidNewInterstitialAd (7.1.1.0):
+    - MintegralAdSDK/BidNativeAd
+    - MintegralAdSDK/NewInterstitialAd
+  - MintegralAdSDK/BidRewardVideoAd (7.1.1.0):
+    - MintegralAdSDK/BidNativeAd
+    - MintegralAdSDK/RewardVideoAd
+  - MintegralAdSDK/InterstitialVideoAd (7.1.1.0):
+    - MintegralAdSDK/NativeAd
+  - MintegralAdSDK/NativeAd (7.1.1.0)
+  - MintegralAdSDK/NewInterstitialAd (7.1.1.0):
+    - MintegralAdSDK/InterstitialVideoAd
+    - MintegralAdSDK/NativeAd
+  - MintegralAdSDK/RewardVideoAd (7.1.1.0):
+    - MintegralAdSDK/NativeAd
 
 DEPENDENCIES:
-  - FairBidSDK (= 3.28.0)
+  - FairBidSDK (= 3.25.0)
+  - MintegralAdSDK (= 7.1.1.0)
+  - MintegralAdSDK/BidInterstitialVideoAd (= 7.1.1.0)
+  - MintegralAdSDK/BidRewardVideoAd (= 7.1.1.0)
+  - MintegralAdSDK/InterstitialVideoAd (= 7.1.1.0)
+  - MintegralAdSDK/RewardVideoAd (= 7.1.1.0)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
     - FairBidSDK
+    - MintegralAdSDK
 
 SPEC CHECKSUMS:
-  FairBidSDK: 473c36188467896143fd3b372b6325ac25f101ee
+  FairBidSDK: e70ca0d83f8a68c2195049cb279dc599fbdc7e8a
+  MintegralAdSDK: 6f4a39e4801633686b58583e3974b8c7c5c064ef
 
-PODFILE CHECKSUM: 4cfc965b668e8483f35c23285aef71b233da6e8b
+PODFILE CHECKSUM: 9bed1bca3bba865489387bbc98753eb554a922aa
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
Use `Podfile` to define versions integrated and then run `pod install`.

— `Podfile` update
— appId `111691`, hardcoded Mintegral placements: `161687`, `161745`, `1724179`